### PR TITLE
Sampler instance from hydra

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -10,6 +10,7 @@ output_path: ???
 
 defaults:
   - model: divae
+  - sampler: gibbsSampler 
   - data: mnist
   - engine: divae_training
   - task

--- a/configs/engine/divae_training.yaml
+++ b/configs/engine/divae_training.yaml
@@ -2,7 +2,5 @@
 learning_rate: 0.001
 n_batch_samples: 256
 n_epochs: 100
-n_gibbs_sampling_steps: 40
-sampling_mode: gibbs_flat
 weight_decay_factor: 0.0001
 momentum_coefficient: 0.5

--- a/configs/sampler/gibbsSampler.yaml
+++ b/configs/sampler/gibbsSampler.yaml
@@ -1,0 +1,3 @@
+# @package _group_
+_target_: models.samplers.gibbsSampler.GibbsSampler
+n_gibbs_sampling_steps: 40

--- a/configs/sampler/pcdSampler.yaml
+++ b/configs/sampler/pcdSampler.yaml
@@ -1,0 +1,4 @@
+# @package _group_
+_target_: models.samplers.pcd.PCD
+n_gibbs_sampling_steps: 40
+batch_size: 32

--- a/models/autoencoders/autoencoderbase.py
+++ b/models/autoencoders/autoencoderbase.py
@@ -75,6 +75,15 @@ class AutoEncoderBase(nn.Module):
 
     def _create_decoder(self):
         raise NotImplementedError
+
+    def _create_sampler(self):
+        """
+            Define the sampler to be used for sampling from the RBM.
+
+        Returns:
+            Instance of baseSampler.
+        """
+        raise NotImplementedError
     
     def generate_samples(self):
         raise NotImplementedError

--- a/models/autoencoders/discreteVAE.py
+++ b/models/autoencoders/discreteVAE.py
@@ -194,7 +194,7 @@ class DiVAE(AutoEncoderBase):
         ######
         # NEGATIVE: samples z_i from prior (RBM)
         ####
-        rbm_samples=self.sampler.get_samples(approx_post_samples=positive_samples_left, n_gibbs_sampling_steps=self._config.engine.n_gibbs_sampling_steps)
+        rbm_samples=self.sampler.get_samples(approx_post_samples=positive_samples_left, n_gibbs_sampling_steps=self._config.sampler.n_gibbs_sampling_steps)
         negative_samples=torch.cat(rbm_samples,dim=1).detach()
         
         # Ep(z,theta) = -zT*Weights*z - zT*bias
@@ -312,7 +312,7 @@ class DiVAE(AutoEncoderBase):
             prior_sample = self.sampler.get_samples(
                 approx_post_samples=[], #empty list, as we want to generate samples from random numbers
                 n_latent_nodes=self.n_latent_nodes,
-                n_gibbs_sampling_steps=self._config.engine.n_gibbs_sampling_steps)
+                n_gibbs_sampling_steps=self._config.sampler.n_gibbs_sampling_steps)
             prior_sample = torch.cat(prior_sample).detach()
             prior_samples.append(prior_sample)
         

--- a/models/autoencoders/discreteVAE.py
+++ b/models/autoencoders/discreteVAE.py
@@ -6,8 +6,9 @@ Author: Eric Drechsler (eric_drechsler@sfu.ca)
 
 import torch
 from torch import nn
-from models.autoencoders.autoencoderbase import AutoEncoderBase
+from hydra.utils import instantiate
 
+from models.autoencoders.autoencoderbase import AutoEncoderBase
 from models.networks.basicCoders import BasicDecoder
 from models.networks.hierarchicalEncoder import HierarchicalEncoder
 from models.rbm.rbm import RBM
@@ -97,7 +98,7 @@ class DiVAE(AutoEncoderBase):
             Instance of GibbsSampler.
         """
         assert self.prior is not None, "Prior (RBM) must be defined."
-        return GibbsSampler(RBM=self.prior, n_gibbs_sampling_steps=self._config.engine.n_gibbs_sampling_steps)
+        return instantiate(self._config.test_sampler,RBM=self.prior)
     
     def _create_encoder(self):
         logger.debug("Creating encoder")

--- a/models/autoencoders/discreteVAE.py
+++ b/models/autoencoders/discreteVAE.py
@@ -1,7 +1,5 @@
 """
 Discrete Variational Autoencoder Class
-
-Author: Eric Drechsler (eric_drechsler@sfu.ca)
 """
 
 import torch
@@ -85,21 +83,20 @@ class DiVAE(AutoEncoderBase):
         logger.debug("Creating Network Structures")
         self.encoder=self._create_encoder()
         self.prior=self._create_prior()
-        self.sampler=self._create_sampler()
         self.decoder=self._create_decoder()
-        return
+        self.sampler = self._create_sampler(rbm=self.prior)
 
-    def _create_sampler(self):
+    def _create_sampler(self, rbm=None):
         logger.debug("Creating sampling routine")
         """
             Define the sampler to be used for sampling from the RBM.
 
         Returns:
-            Instance of GibbsSampler.
+            Instance of BaseSampler.
         """
-        assert self.prior is not None, "Prior (RBM) must be defined."
-        return instantiate(self._config.test_sampler,RBM=self.prior)
-    
+        assert rbm is not None, "Prior (RBM) must be defined."
+        return instantiate(self._config.sampler,RBM=self.prior)
+
     def _create_encoder(self):
         logger.debug("Creating encoder")
         return HierarchicalEncoder(

--- a/models/autoencoders/discreteVAE.py
+++ b/models/autoencoders/discreteVAE.py
@@ -95,7 +95,7 @@ class DiVAE(AutoEncoderBase):
             Instance of BaseSampler.
         """
         assert rbm is not None, "Prior (RBM) must be defined."
-        return instantiate(self._config.sampler,RBM=self.prior)
+        return instantiate(self._config.sampler,RBM=rbm)
 
     def _create_encoder(self):
         logger.debug("Creating encoder")

--- a/models/autoencoders/dvaepp.py
+++ b/models/autoencoders/dvaepp.py
@@ -44,22 +44,6 @@ class DiVAEPP(DiVAE):
             smoother="MixtureExp",
             cfg=self._config)
     
-    def _create_sampler(self):
-        """
-        - Overrides _create_sampler in discreteVAE.py
-        
-        Returns:
-            PCD Sampler
-        """
-        return PCD(batchSize=32, RBM=self.prior, n_gibbs_sampling_steps=40)
-    
-    def create_networks(self):
-        logger.debug("Creating Network Structures")
-        self.encoder = self._create_encoder()
-        self.prior = self._create_prior()
-        self.decoder = self._create_decoder()
-        self.sampler = self._create_sampler()
-        
     def kl_divergence(self, post_dists, post_samples, is_training=True):
         """
         - Compute KLD b.w. hierarchical posterior and RBM prior for DVAE++

--- a/models/rbm/rbm.py
+++ b/models/rbm/rbm.py
@@ -46,6 +46,9 @@ class RBM(nn.Module):
     def weights(self):
         return self._weights
 
+    def __repr__(self):
+        return "RBM: n_vis={0}, n_hid={1}".format(self._n_visible,self._n_hidden)
+
     def get_logZ_value(self):
         #TODO include calculation of this value
         # this hardcoded number is taken from Figure 10 Rolfe

--- a/models/rbm/rbm.py
+++ b/models/rbm/rbm.py
@@ -1,8 +1,6 @@
 
 """
 PyTorch implementation of a restricted Boltzmann machine
-
-Author: Eric Drechsler (eric_drechsler@sfu.ca)
 """
 
 import numpy as np

--- a/models/samplers/baseSampler.py
+++ b/models/samplers/baseSampler.py
@@ -8,7 +8,13 @@ class BaseSampler(nn.Module):
     def __init__(self, n_gibbs_sampling_steps, **kwargs):
         super(BaseSampler, self).__init__(**kwargs)
         self.n_gibbs_sampling_steps = n_gibbs_sampling_steps
-
+    
+    def __repr__(self):
+        outstring=""
+        for key,val in self.__dict__.items():
+            outstring+="{0}: {1}\n".format(key,val)
+        return outstring
+    
     def visible_samples(self):
         raise NotImplementedError
 

--- a/models/samplers/gibbsSampler.py
+++ b/models/samplers/gibbsSampler.py
@@ -16,12 +16,6 @@ class GibbsSampler(BaseSampler):
     def __init__(self, RBM, **kwargs):
         super(GibbsSampler, self).__init__(**kwargs)
         self._RBM = RBM
-    
-    def __repr__(self):
-        outstring=""
-        for key,val in self.__dict__.items():
-            outstring+="{0}: {1}\n".format(key,val)
-        return outstring
 
     def hidden_samples(self, probabilities_visible):
         output_hidden = torch.matmul(probabilities_visible, self._RBM.weights) + self._RBM.hidden_bias

--- a/models/samplers/gibbsSampler.py
+++ b/models/samplers/gibbsSampler.py
@@ -16,7 +16,13 @@ class GibbsSampler(BaseSampler):
     def __init__(self, RBM, **kwargs):
         super(GibbsSampler, self).__init__(**kwargs)
         self._RBM = RBM
-        
+    
+    def __repr__(self):
+        outstring=""
+        for key,val in self.__dict__.items():
+            outstring+="{0}: {1}\n".format(key,val)
+        return outstring
+
     def hidden_samples(self, probabilities_visible):
         output_hidden = torch.matmul(probabilities_visible, self._RBM.weights) + self._RBM.hidden_bias
         probabilities_hidden = torch.sigmoid(output_hidden)

--- a/models/samplers/pcd.py
+++ b/models/samplers/pcd.py
@@ -9,21 +9,21 @@ import torch
 
 class PCD(BaseSampler):
     
-    def __init__(self, batchSize, RBM, **kwargs):
+    def __init__(self, batch_size, RBM, **kwargs):
         super(PCD, self).__init__(**kwargs)
         
         self._RBM = RBM
-        self._MCState = (torch.rand(batchSize, self._RBM.visible_bias.size(0)) >= 
-                         torch.rand(batchSize, self._RBM.visible_bias.size(0))).float()
+        self._MCState = (torch.rand(batch_size, self._RBM.visible_bias.size(0)) >= 
+                         torch.rand(batch_size, self._RBM.visible_bias.size(0))).float()
         
     def hidden_samples(self, visible_states):
         """
         Sample batch of hidden states given a batch of visible states
         
         Args:
-            visible_states : Tensor, Dims=(batchSize * nVisibleNodes)
+            visible_states : Tensor, Dims=(batch_size * nVisibleNodes)
         Output:
-            hidden_states sample : Tensor, Dims=(batchSize * nHiddenNodes)
+            hidden_states sample : Tensor, Dims=(batch_size * nHiddenNodes)
         """
         hidden_activations = (torch.matmul(visible_states, self._RBM.weights)
                           + self._RBM.hidden_bias)
@@ -35,9 +35,9 @@ class PCD(BaseSampler):
         Sample batch of visible states given a batch of hidden states
         
         Args:
-            hidden_states : Tensor, Dims=(batchSize * nHiddenNodes)
+            hidden_states : Tensor, Dims=(batch_size * nHiddenNodes)
         Output:
-            visible_states sample : Tensor, Dims=(batchSize * nVisibleNodes)
+            visible_states sample : Tensor, Dims=(batch_size * nVisibleNodes)
         """
         visible_activations = (torch.matmul(hidden_states, self._RBM.weights.t()) 
                            + self._RBM.visible_bias)
@@ -49,8 +49,8 @@ class PCD(BaseSampler):
         Block Gibbs sampling with initialization through a persistent Markov Chain
         
         Returns:
-            visible_states : Batch of visible states at end of Gibbs sampling, Dims=(batchSize * nVisibleNodes)
-            hidden_states : Batch of hidden states at end of Gibbs sampling, Dims=(batchSize * nHiddenNodes)
+            visible_states : Batch of visible states at end of Gibbs sampling, Dims=(batch_size * nVisibleNodes)
+            hidden_states : Batch of hidden states at end of Gibbs sampling, Dims=(batch_size * nHiddenNodes)
         """
         visible_states = self._MCState
         for step in range(self.n_gibbs_sampling_steps):


### PR DESCRIPTION
Hey @abhishekabhishek ,

check this out: instead of hardcoding the sampler in each model, we can now steer this via the configuration. Hydra provides a method `instantiate`, which allows you to define a target-object and init-arguments in a cfg file and instantiate the object with these settings during runtime. That's pretty nifty - let's say you would like to run the DiVAE model with the `PCD` sampler instead of the single `GibbsSampler`, just do:
```
python scripts/run.py sampler=pcdSampler
```
to overwrite the default setting.

I hope to include this steerability in more aspects of the code in the future.

Cheers!

Adresses #10 
